### PR TITLE
fix: broken discord links

### DIFF
--- a/docs/guide/mint.mdx
+++ b/docs/guide/mint.mdx
@@ -140,7 +140,7 @@ Ensure you have enough tokens to cover the gas fees—typically less than $0.10 
 
 ## Future releases
 
-In future release, you will be able to modify additional fields. In this release, you can't change their default value. If it is necessary for your project to adjust these default values, please contact us in our [discord help forum](https://discord.gg/UZt8cBnP4w).
+In future release, you will be able to modify additional fields. In this release, you can't change their default value. If it is necessary for your project to adjust these default values, please contact us in our [discord help forum](https://discord.gg/azPgDcSQWw).
 
 <details>
   <summary>Impact Scope</summary>

--- a/docs/guide/start.md
+++ b/docs/guide/start.md
@@ -8,7 +8,7 @@ sidebar_position: 1
 
 Creating, transfering, selling, and buying a hypercert is similar to interacting with an NFT on platforms like OpenSea or Looksrare. 
 
-In this guide we will provide you all information to get started. If anything is missing or if you are stuck in the process, please jump on [our discord server](https://discord.gg/UZt8cBnP4w) and enter the help forum there.
+In this guide we will provide you all information to get started. If anything is missing or if you are stuck in the process, please jump on [our discord server](https://discord.gg/azPgDcSQWw) and enter the help forum there.
 
 ### Who Can Use Hypercerts?
 
@@ -48,7 +48,7 @@ If you want to sell multiple hypercerts as a project or a funding program operat
 
 ### What Do I Need to Use Hypercerts?
 
-To interact with Hypercerts, you’ll need a crypto wallet. If you’re new to the Web3 space, we recommend familiarizing yourself with the tools first. Don’t worry—we’re here to help! You can reach us in the [discord help forum](https://discord.gg/UZt8cBnP4w).
+To interact with Hypercerts, you’ll need a crypto wallet. If you’re new to the Web3 space, we recommend familiarizing yourself with the tools first. Don’t worry—we’re here to help! You can reach us in the [discord help forum](https://discord.gg/azPgDcSQWw).
 
 You’ll also need a small amount of gas on the network you choose to interact with. The Hypercerts protocol is available on Optimism, Celo, Base, Arbitrum, and Sepolia (testnet). For example, minting a Hypercert typically costs less than $0.10 USD.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,7 +113,7 @@ export default async function createConfigAsync() {
                         <a href="https://twitter.com/hypercerts" target="_blank" rel="noopener noreferrer" title="Follow us on Twitter">
                             <img src="/img/social-icons/x.svg" alt="Twitter" width="30px" height="30px" style="margin: 0 10px;" />
                         </a>
-                        <a href="https://discord.gg/VVSyKg75" target="_blank" rel="noopener noreferrer" title="Join us on Discord">
+                        <a href="https://discord.gg/azPgDcSQWw" target="_blank" rel="noopener noreferrer" title="Join us on Discord">
                             <img src="/img/social-icons/discord.svg" alt="Discord" width="30px" height="30px" style="margin: 0 10px;" />
                         </a>
                         <a href="https://hypercerts.org" rel="noopener noreferrer" title="Visit the Hypercerts website">

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -43,7 +43,7 @@ function HomepageHeader() {
           <p>Join our <a href="https://t.me/+YF9AYb6zCv1mNDJi" target="_blank" rel="noopener noreferrer">Telegram Group</a> to stay up to date.</p>
           <p>And find your way to our <a href="https://github.com/hypercerts-org/hypercerts" target="_blank" rel="noopener noreferrer">GitHub</a> to follow our technical development.</p>
           <h3>Get support</h3>
-          <p>Need help? Join our <a href="https://discord.gg/UZt8cBnP4w" target="_blank" rel="noopener noreferrer">Discord</a> and post in the help forum.</p>
+          <p>Need help? Join our <a href="https://discord.gg/azPgDcSQWw" target="_blank" rel="noopener noreferrer">Discord</a> and post in the help forum.</p>
         </div>
       </div>
         


### PR DESCRIPTION
replaced old link with new one that doesn't expire