### PR TITLE
Add blog subdomain support and OG images from post content

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -26,7 +26,7 @@ export async function generateMetadata({ params }: Props) {
       authors: ["Hypercerts Foundation"],
       images: [
         {
-          url: "/img/hypercerts_opengraph-v2.jpg",
+          url: post.image ?? "/img/hypercerts_opengraph-v2.jpg",
           width: 1200,
           height: 630,
           alt: post.title,
@@ -37,7 +37,7 @@ export async function generateMetadata({ params }: Props) {
       card: "summary_large_image",
       title: post.title,
       description: post.description,
-      images: ["/img/hypercerts_opengraph-v2.jpg"],
+      images: [post.image ?? "/img/hypercerts_opengraph-v2.jpg"],
     },
   };
 }
@@ -79,7 +79,7 @@ export default async function BlogPostPage({ params }: Props) {
               datePublished: isoDate,
               image: {
                 "@type": "ImageObject",
-                url: "https://hypercerts.org/img/hypercerts_opengraph-v2.jpg",
+                url: post.image ?? "https://hypercerts.org/img/hypercerts_opengraph-v2.jpg",
                 width: 1200,
                 height: 630,
               },

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { fetchBlogPost, fetchBlogPosts } from "@/lib/blog";
+import { blogPath, blogCanonical, blogAbsoluteUrl } from "@/lib/blog-url";
 
 interface Props {
   params: Promise<{ slug: string }>;
@@ -14,12 +15,12 @@ export async function generateMetadata({ params }: Props) {
     title: post.title,
     description: post.description,
     alternates: {
-      canonical: `https://hypercerts.org/blog/${slug}`,
+      canonical: blogCanonical(slug),
     },
     openGraph: {
       title: `${post.title} | Hypercerts Blog`,
       description: post.description,
-      url: `https://hypercerts.org/blog/${slug}`,
+      url: blogCanonical(slug),
       type: "article",
       publishedTime: new Date(post.pubDate).toISOString(),
       authors: ["Hypercerts Foundation"],
@@ -59,6 +60,9 @@ export default async function BlogPostPage({ params }: Props) {
   });
 
   const isoDate = new Date(post.pubDate).toISOString();
+  const backHref = await blogPath();
+  const canonical = blogCanonical(slug);
+  const absoluteUrl = blogAbsoluteUrl(slug);
 
   return (
     <main className="bg-white py-24 md:py-32">
@@ -69,7 +73,7 @@ export default async function BlogPostPage({ params }: Props) {
             {
               "@context": "https://schema.org",
               "@type": "Article",
-              "@id": `https://hypercerts.org/blog/${slug}#article`,
+              "@id": `${absoluteUrl}#article`,
               headline: post.title,
               description: post.description,
               datePublished: isoDate,
@@ -96,7 +100,7 @@ export default async function BlogPostPage({ params }: Props) {
               },
               mainEntityOfPage: {
                 "@type": "WebPage",
-                "@id": `https://hypercerts.org/blog/${slug}`,
+                "@id": canonical,
               },
             },
             {
@@ -113,7 +117,7 @@ export default async function BlogPostPage({ params }: Props) {
                   "@type": "ListItem",
                   position: 2,
                   name: "Blog",
-                  item: "https://hypercerts.org/blog",
+                  item: blogCanonical(),
                 },
                 {
                   "@type": "ListItem",
@@ -128,7 +132,7 @@ export default async function BlogPostPage({ params }: Props) {
       <article className="max-w-3xl mx-auto px-6">
         {/* Back link */}
         <Link
-          href="/blog"
+          href={backHref}
           className="font-body text-body-sm text-brand-accent hover:text-brand-black transition mb-10 inline-block"
         >
           &larr; All posts
@@ -164,7 +168,7 @@ export default async function BlogPostPage({ params }: Props) {
         {/* Footer */}
         <div className="mt-16 pt-8 border-t border-ui-separator">
           <Link
-            href="/blog"
+            href={backHref}
             className="font-body text-body-sm text-brand-black font-medium hover:underline"
           >
             &larr; All posts

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,19 +1,27 @@
 import Link from "next/link";
 import { fetchBlogPosts } from "@/lib/blog";
+import { blogPath, blogCanonical } from "@/lib/blog-url";
 
 export const metadata = {
   title: "Blog",
   description:
     "Updates from the Hypercerts Foundation on protocol development and highlights from across the ecosystem.",
+  alternates: {
+    canonical: blogCanonical(),
+  },
   openGraph: {
     title: "Blog | Hypercerts",
     description:
       "Updates from the Hypercerts Foundation on protocol development and highlights from across the ecosystem.",
+    url: blogCanonical(),
   },
 };
 
 export default async function BlogPage() {
   const posts = await fetchBlogPosts();
+  const postPaths = await Promise.all(
+    posts.map((post) => blogPath(post.slug))
+  );
 
   return (
     <main className="bg-white py-24 md:py-32">
@@ -53,10 +61,10 @@ export default async function BlogPage() {
           </p>
         ) : (
           <div className="space-y-0">
-            {posts.map((post) => (
+            {posts.map((post, i) => (
               <Link
                 key={post.slug}
-                href={`/blog/${post.slug}`}
+                href={postPaths[i]}
                 className="group block border-t border-ui-separator py-10 first:border-t first:border-brand-accent/40"
               >
                 <div className="grid md:grid-cols-[1fr_auto] gap-6 md:gap-12 items-start">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,11 +1,12 @@
 import type { MetadataRoute } from "next";
 import { fetchBlogPosts } from "@/lib/blog";
+import { blogCanonical } from "@/lib/blog-url";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = await fetchBlogPosts();
 
   const blogEntries = posts.map((post) => ({
-    url: `https://hypercerts.org/blog/${post.slug}`,
+    url: blogCanonical(post.slug),
     lastModified: new Date(post.pubDate),
     changeFrequency: "monthly" as const,
     priority: 0.7,
@@ -19,7 +20,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 1,
     },
     {
-      url: "https://hypercerts.org/blog",
+      url: blogCanonical(),
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 0.8,

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,11 +4,12 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
-import { headerNavLinks as navLinks } from "@/lib/data/navigation";
+import { getHeaderNavLinks } from "@/lib/data/navigation";
 
 export default function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
   const pathname = usePathname();
+  const navLinks = getHeaderNavLinks();
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-white h-[50px] flex items-center px-6 border-b border-ui-separator">

--- a/lib/blog-url.ts
+++ b/lib/blog-url.ts
@@ -1,0 +1,48 @@
+import { headers } from "next/headers";
+
+const BLOG_ORIGIN = "https://blog.hypercerts.org";
+const MAIN_ORIGIN = "https://hypercerts.org";
+
+/**
+ * Returns true when the request is served from blog.hypercerts.org.
+ * Reads the x-blog-host header set by middleware.
+ */
+export async function isBlogHost(): Promise<boolean> {
+  const h = await headers();
+  return h.get("x-blog-host") === "1";
+}
+
+/**
+ * Returns the path for a blog link, subdomain-aware.
+ * On blog.hypercerts.org: /slug
+ * On hypercerts.org:      /blog/slug
+ */
+export async function blogPath(slug?: string): Promise<string> {
+  const onBlog = await isBlogHost();
+  if (slug) {
+    return onBlog ? `/${slug}` : `/blog/${slug}`;
+  }
+  return onBlog ? "/" : "/blog";
+}
+
+/**
+ * Returns the canonical URL for a blog page.
+ * Always uses blog.hypercerts.org as the canonical origin.
+ */
+export function blogCanonical(slug?: string): string {
+  if (slug) {
+    return `${BLOG_ORIGIN}/${slug}`;
+  }
+  return BLOG_ORIGIN;
+}
+
+/**
+ * Returns the full absolute URL on the main domain.
+ * Used for structured data that should always reference hypercerts.org.
+ */
+export function blogAbsoluteUrl(slug?: string): string {
+  if (slug) {
+    return `${MAIN_ORIGIN}/blog/${slug}`;
+  }
+  return `${MAIN_ORIGIN}/blog`;
+}

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -180,6 +180,16 @@ function renderBlocks(pages: { blocks?: { block: Block }[] }[]): string {
 }
 
 function findFirstImage(pages: { blocks?: { block: Block }[] }[]): string | undefined {
+  // 1. Look for an image block first
+  for (const page of pages) {
+    for (const entry of page.blocks ?? []) {
+      const block = entry.block;
+      if (block.$type === "pub.leaflet.blocks.image" && block.url) {
+        return block.url;
+      }
+    }
+  }
+  // 2. Fall back to YouTube thumbnail
   for (const page of pages) {
     for (const entry of page.blocks ?? []) {
       const block = entry.block;

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -5,6 +5,7 @@ export interface BlogPost {
   description: string;
   content: string;
   pubDate: string;
+  image?: string;
 }
 
 const DID = "did:plc:s4puetfspot742ai7y4otuel";
@@ -178,6 +179,21 @@ function renderBlocks(pages: { blocks?: { block: Block }[] }[]): string {
   return html.join("\n");
 }
 
+function findFirstImage(pages: { blocks?: { block: Block }[] }[]): string | undefined {
+  for (const page of pages) {
+    for (const entry of page.blocks ?? []) {
+      const block = entry.block;
+      if (block.$type === "pub.leaflet.blocks.iframe" && block.url) {
+        const match = block.url.match(/youtube\.com\/embed\/([^?/]+)/);
+        if (match) {
+          return `https://img.youtube.com/vi/${match[1]}/maxresdefault.jpg`;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
 function stripHtml(html: string): string {
   return html
     .replace(/<[^>]*>/g, "")
@@ -221,9 +237,9 @@ export async function fetchBlogPosts(): Promise<BlogPost[]> {
       .map((r) => {
         const { title, description: rawDesc, path, publishedAt, content } = r.value;
         const slug = path.replace(/^\//, "");
-        const htmlContent = content?.pages
-          ? renderBlocks(content.pages)
-          : "";
+        const pages = content?.pages ?? [];
+        const htmlContent = pages.length ? renderBlocks(pages) : "";
+        const image = findFirstImage(pages);
         const description = rawDesc
           || (() => {
             const plainText = stripHtml(htmlContent);
@@ -237,6 +253,7 @@ export async function fetchBlogPosts(): Promise<BlogPost[]> {
           description,
           content: htmlContent,
           pubDate: publishedAt!,
+          image,
         };
       })
       .sort(

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -180,19 +180,12 @@ function renderBlocks(pages: { blocks?: { block: Block }[] }[]): string {
 }
 
 function findFirstImage(pages: { blocks?: { block: Block }[] }[]): string | undefined {
-  // 1. Look for an image block first
   for (const page of pages) {
     for (const entry of page.blocks ?? []) {
       const block = entry.block;
       if (block.$type === "pub.leaflet.blocks.image" && block.url) {
         return block.url;
       }
-    }
-  }
-  // 2. Fall back to YouTube thumbnail
-  for (const page of pages) {
-    for (const entry of page.blocks ?? []) {
-      const block = entry.block;
       if (block.$type === "pub.leaflet.blocks.iframe" && block.url) {
         const match = block.url.match(/youtube\.com\/embed\/([^?/]+)/);
         if (match) {

--- a/lib/data/navigation.ts
+++ b/lib/data/navigation.ts
@@ -9,17 +9,27 @@ export interface NavColumn {
   links: NavLink[];
 }
 
-export const headerNavLinks: NavLink[] = [
-  { label: "Blog", href: "/blog" },
-  { label: "Contact", href: "/contact" },
-  { label: "Docs \u2197", href: "https://docs.hypercerts.org", external: true },
-];
+const BLOG_HOST = "blog.hypercerts.org";
+
+function isBlogHostClient(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.location.hostname === BLOG_HOST;
+}
+
+export function getHeaderNavLinks(): NavLink[] {
+  const blogHref = isBlogHostClient() ? "/" : "/blog";
+  return [
+    { label: "Blog", href: blogHref },
+    { label: "Contact", href: isBlogHostClient() ? "https://hypercerts.org/contact" : "/contact" },
+    { label: "Docs \u2197", href: "https://docs.hypercerts.org", external: true },
+  ];
+}
 
 export const footerNavColumns: NavColumn[] = [
   {
     header: "Resources",
     links: [
-      { label: "Blog", href: "/blog" },
+      { label: "Blog", href: "https://blog.hypercerts.org" },
       { label: "Docs", href: "https://docs.hypercerts.org" },
       { label: "GitHub", href: "https://github.com/hypercerts-org" },
     ],

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BLOG_HOST = "blog.hypercerts.org";
+
+export function middleware(request: NextRequest) {
+  const host = request.headers.get("host")?.split(":")[0] ?? "";
+  const isBlogSubdomain = host === BLOG_HOST;
+
+  if (!isBlogSubdomain) {
+    return NextResponse.next();
+  }
+
+  const { pathname } = request.nextUrl;
+
+  // Paths that should NOT be rewritten to /blog/...
+  // (assets, Next internals, static pages served on the main domain)
+  if (
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/api") ||
+    pathname.startsWith("/img") ||
+    pathname.startsWith("/fonts") ||
+    pathname.match(/\.\w+$/) // static files (favicon.ico, robots.txt, etc.)
+  ) {
+    const response = NextResponse.next();
+    response.headers.set("x-blog-host", "1");
+    return response;
+  }
+
+  // Root → blog index
+  if (pathname === "/") {
+    const url = request.nextUrl.clone();
+    url.pathname = "/blog";
+    const response = NextResponse.rewrite(url);
+    response.headers.set("x-blog-host", "1");
+    return response;
+  }
+
+  // Already starts with /blog — pass through (handles direct /blog access)
+  if (pathname.startsWith("/blog")) {
+    const response = NextResponse.next();
+    response.headers.set("x-blog-host", "1");
+    return response;
+  }
+
+  // Rewrite /<slug> → /blog/<slug>
+  const url = request.nextUrl.clone();
+  url.pathname = `/blog${pathname}`;
+  const response = NextResponse.rewrite(url);
+  response.headers.set("x-blog-host", "1");
+  return response;
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image).*)",
+  ],
+};


### PR DESCRIPTION
## Summary
- **Blog subdomain**: `blog.hypercerts.org` support via Next.js middleware. Rewrites `/<slug>` → `/blog/<slug>` internally. Links are subdomain-aware. Canonical URLs use `blog.hypercerts.org`.
- **OG images**: Uses first image or YouTube thumbnail from post content as OpenGraph/Twitter image. Falls back to default Hypercerts image.
- **URL helpers**: Centralizes blog URL logic in `lib/blog-url.ts` (`blogPath`, `blogCanonical`, `blogAbsoluteUrl`).

## Vercel setup required
- Add `blog.hypercerts.org` as a domain in Vercel project settings

## Test plan
- [ ] `blog.hypercerts.org/` serves blog index, `blog.hypercerts.org/<slug>` serves posts
- [ ] Links on blog subdomain don't include `/blog` prefix
- [ ] `hypercerts.org/blog/...` continues to work
- [ ] OG image shows YouTube thumbnail when sharing posts with video
- [ ] OG image falls back to default for posts without video/image
- [ ] Responsive iframe sizing on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated blog subdomain (blog.hypercerts.org) enabling streamlined content organization and access
  * Implemented featured image support for blog posts to enhance visual presentation
  * Dynamic navigation that intelligently adapts based on subdomain context for seamless user experience

* **Improvements**
  * Enhanced URL standardization and metadata handling to improve search engine discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->