### PR TITLE
Use post content images as OpenGraph thumbnails

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: Props) {
       authors: ["Hypercerts Foundation"],
       images: [
         {
-          url: "/img/hypercerts_opengraph-v2.jpg",
+          url: post.image ?? "/img/hypercerts_opengraph-v2.jpg",
           width: 1200,
           height: 630,
           alt: post.title,
@@ -36,7 +36,7 @@ export async function generateMetadata({ params }: Props) {
       card: "summary_large_image",
       title: post.title,
       description: post.description,
-      images: ["/img/hypercerts_opengraph-v2.jpg"],
+      images: [post.image ?? "/img/hypercerts_opengraph-v2.jpg"],
     },
   };
 }
@@ -75,7 +75,7 @@ export default async function BlogPostPage({ params }: Props) {
               datePublished: isoDate,
               image: {
                 "@type": "ImageObject",
-                url: "https://hypercerts.org/img/hypercerts_opengraph-v2.jpg",
+                url: post.image ?? "https://hypercerts.org/img/hypercerts_opengraph-v2.jpg",
                 width: 1200,
                 height: 630,
               },

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -180,6 +180,16 @@ function renderBlocks(pages: { blocks?: { block: Block }[] }[]): string {
 }
 
 function findFirstImage(pages: { blocks?: { block: Block }[] }[]): string | undefined {
+  // 1. Look for an image block first
+  for (const page of pages) {
+    for (const entry of page.blocks ?? []) {
+      const block = entry.block;
+      if (block.$type === "pub.leaflet.blocks.image" && block.url) {
+        return block.url;
+      }
+    }
+  }
+  // 2. Fall back to YouTube thumbnail
   for (const page of pages) {
     for (const entry of page.blocks ?? []) {
       const block = entry.block;

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -5,6 +5,7 @@ export interface BlogPost {
   description: string;
   content: string;
   pubDate: string;
+  image?: string;
 }
 
 const DID = "did:plc:s4puetfspot742ai7y4otuel";
@@ -178,6 +179,21 @@ function renderBlocks(pages: { blocks?: { block: Block }[] }[]): string {
   return html.join("\n");
 }
 
+function findFirstImage(pages: { blocks?: { block: Block }[] }[]): string | undefined {
+  for (const page of pages) {
+    for (const entry of page.blocks ?? []) {
+      const block = entry.block;
+      if (block.$type === "pub.leaflet.blocks.iframe" && block.url) {
+        const match = block.url.match(/youtube\.com\/embed\/([^?/]+)/);
+        if (match) {
+          return `https://img.youtube.com/vi/${match[1]}/maxresdefault.jpg`;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
 function stripHtml(html: string): string {
   return html
     .replace(/<[^>]*>/g, "")
@@ -221,9 +237,9 @@ export async function fetchBlogPosts(): Promise<BlogPost[]> {
       .map((r) => {
         const { title, description: rawDesc, path, publishedAt, content } = r.value;
         const slug = path.replace(/^\//, "");
-        const htmlContent = content?.pages
-          ? renderBlocks(content.pages)
-          : "";
+        const pages = content?.pages ?? [];
+        const htmlContent = pages.length ? renderBlocks(pages) : "";
+        const image = findFirstImage(pages);
         const description = rawDesc
           || (() => {
             const plainText = stripHtml(htmlContent);
@@ -237,6 +253,7 @@ export async function fetchBlogPosts(): Promise<BlogPost[]> {
           description,
           content: htmlContent,
           pubDate: publishedAt!,
+          image,
         };
       })
       .sort(

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -180,19 +180,12 @@ function renderBlocks(pages: { blocks?: { block: Block }[] }[]): string {
 }
 
 function findFirstImage(pages: { blocks?: { block: Block }[] }[]): string | undefined {
-  // 1. Look for an image block first
   for (const page of pages) {
     for (const entry of page.blocks ?? []) {
       const block = entry.block;
       if (block.$type === "pub.leaflet.blocks.image" && block.url) {
         return block.url;
       }
-    }
-  }
-  // 2. Fall back to YouTube thumbnail
-  for (const page of pages) {
-    for (const entry of page.blocks ?? []) {
-      const block = entry.block;
       if (block.$type === "pub.leaflet.blocks.iframe" && block.url) {
         const match = block.url.match(/youtube\.com\/embed\/([^?/]+)/);
         if (match) {

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -179,17 +179,26 @@ function renderBlocks(pages: { blocks?: { block: Block }[] }[]): string {
   return html.join("\n");
 }
 
+function isSafeUrl(url: string): boolean {
+  try {
+    const scheme = new URL(url).protocol;
+    return scheme === "https:" || scheme === "http:";
+  } catch {
+    return false;
+  }
+}
+
 function findFirstImage(pages: { blocks?: { block: Block }[] }[]): string | undefined {
   for (const page of pages) {
     for (const entry of page.blocks ?? []) {
       const block = entry.block;
-      if (block.$type === "pub.leaflet.blocks.image" && block.url) {
+      if (block.$type === "pub.leaflet.blocks.image" && block.url && isSafeUrl(block.url)) {
         return block.url;
       }
       if (block.$type === "pub.leaflet.blocks.iframe" && block.url) {
         const match = block.url.match(/youtube\.com\/embed\/([^?/]+)/);
         if (match) {
-          return `https://img.youtube.com/vi/${match[1]}/maxresdefault.jpg`;
+          return `https://img.youtube.com/vi/${match[1]}/hqdefault.jpg`;
         }
       }
     }


### PR DESCRIPTION
## Summary
- Extracts the first image or YouTube video thumbnail from blog post content for use as the OpenGraph/Twitter image
- Uses whichever visual block appears first in document order (image block or YouTube embed)
- Falls back to the default Hypercerts OG image for posts without visual content

## Test plan
- [ ] Posts with YouTube videos show video thumbnail when shared (e.g. ATmosphereConf post)
- [ ] Posts without video/image fall back to default Hypercerts OG image
- [ ] Verify meta tags with `curl -s <url> | grep og:image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog posts now automatically extract and display custom images from post content, including embedded images and YouTube video thumbnails, for use in Open Graph metadata and social media sharing previews.
  * Enhanced social media sharing by using post-specific images instead of generic fallback images, improving content visibility across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->