### PR TITLE
Revert YouTube OG thumbnails to maxresdefault

### DIFF
--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -198,7 +198,7 @@ function findFirstImage(pages: { blocks?: { block: Block }[] }[]): string | unde
       if (block.$type === "pub.leaflet.blocks.iframe" && block.url) {
         const match = block.url.match(/youtube\.com\/embed\/([^?/]+)/);
         if (match) {
-          return `https://img.youtube.com/vi/${match[1]}/hqdefault.jpg`;
+          return `https://img.youtube.com/vi/${match[1]}/maxresdefault.jpg`;
         }
       }
     }


### PR DESCRIPTION
## Summary
- Reverts YouTube OG thumbnail path from hqdefault.jpg back to maxresdefault.jpg
- hqdefault.jpg is only 480x360 which is too small for social platform previews
- maxresdefault.jpg (1280x720) is available for all modern HD YouTube uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)