### PR TITLE
Remove Telegram Support link from org profile

### DIFF
--- a/ORG_PROFILE_README.md
+++ b/ORG_PROFILE_README.md
@@ -106,7 +106,6 @@ You do not need to adopt the entire stack to use hypercerts—individual compone
 - [Bluesky](https://bsky.app/profile/hypercerts.org)
 - [Twitter](https://x.com/hypercerts)
 - [Telegram](https://t.me/+o4wPsJ7yEZYzNGFk)
-- [Telegram Support](https://t.me/+FODiLtCV2TgwNzRi)
 
 # Supporters
 


### PR DESCRIPTION
## Summary
- Remove the "Telegram Support" link from the Contact section in ORG_PROFILE_README.md.

## Test plan
- [ ] Confirm the org profile README only lists the main Telegram link under Contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)