### PR TITLE
Add site-wide announcement banner below the navbar

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -61,7 +61,7 @@ export default async function BlogPostPage({ params }: Props) {
   const isoDate = new Date(post.pubDate).toISOString();
 
   return (
-    <main className="bg-white py-24 md:py-32">
+    <main id="main-content" tabIndex={-1} className="bg-white py-24 md:py-32 outline-none">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -16,7 +16,7 @@ export default async function BlogPage() {
   const posts = await fetchBlogPosts();
 
   return (
-    <main className="bg-white py-24 md:py-32">
+    <main id="main-content" tabIndex={-1} className="bg-white py-24 md:py-32 outline-none">
       <p className="sr-only">
         The Hypercerts blog publishes updates on protocol development, ecosystem
         highlights, and perspectives on impact funding from the Hypercerts

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -100,7 +100,7 @@ const faqs = [
 
 export default function ContactPage() {
   return (
-    <main className="bg-white py-24 md:py-32">
+    <main id="main-content" tabIndex={-1} className="bg-white py-24 md:py-32 outline-none">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -14,7 +14,7 @@ export default function Error({
   }, [error]);
 
   return (
-    <main className="min-h-screen flex items-center justify-center bg-white">
+    <main id="main-content" tabIndex={-1} className="min-h-screen flex items-center justify-center bg-white outline-none">
       <div className="text-center px-6">
         <h1 className="font-display text-display-2 text-brand-black">
           Something went wrong

--- a/app/globals.css
+++ b/app/globals.css
@@ -32,6 +32,9 @@
   h1, h2, h3 {
     @apply font-display;
   }
+  html[data-banner-hidden] [data-banner-role="announcement"] {
+    display: none !important;
+  }
 }
 
 @keyframes fade-in {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
+import AnnouncementBanner from "@/components/AnnouncementBanner";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://hypercerts.org"),
@@ -104,8 +105,10 @@ export default function RootLayout({
           Skip to content
         </a>
         <Header />
+        <AnnouncementBanner />
         {children}
         <Footer />
+        <div id="banner-status" className="sr-only" aria-live="polite" />
       </body>
     </html>
   );

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <main className="min-h-screen flex items-center justify-center bg-white">
+    <main id="main-content" tabIndex={-1} className="min-h-screen flex items-center justify-center bg-white outline-none">
       <div className="text-center px-6">
         <h1 className="font-display text-display-1 max-sm:text-[80px] text-brand-black">
           404

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -125,7 +125,7 @@ const geoStructuredData = [
 
 export default function Home() {
   return (
-    <main id="main-content">
+    <main id="main-content" tabIndex={-1} className="outline-none">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -4,7 +4,7 @@ export const metadata = {
 
 export default function PrivacyPage() {
   return (
-    <main className="bg-white py-24 md:py-32">
+    <main id="main-content" tabIndex={-1} className="bg-white py-24 md:py-32 outline-none">
       <article className="max-w-3xl mx-auto px-6 font-body text-brand-black">
         <h1 className="font-display text-[36px] sm:text-[48px] md:text-display-2 leading-[1] tracking-[-0.02em] mb-12">
           Privacy Policy

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -4,7 +4,7 @@ export const metadata = {
 
 export default function TermsPage() {
   return (
-    <main className="bg-white py-24 md:py-32">
+    <main id="main-content" tabIndex={-1} className="bg-white py-24 md:py-32 outline-none">
       <article className="max-w-3xl mx-auto px-6 font-body text-brand-black">
         <h1 className="font-display text-[36px] sm:text-[48px] md:text-display-2 leading-[1] tracking-[-0.02em] mb-12">
           Terms of Use

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -20,7 +20,7 @@ const parseExpiry = (v?: string): number | null => {
 const buildPreHideScript = (id: string, exp: number | null) =>
   `(function(){try{var id=${safeScriptJSON(id)},exp=${
     Number.isFinite(exp as number) ? String(exp) : "null"
-  };if(exp!==null&&Date.now()>=exp){document.documentElement.setAttribute("data-banner-hidden","expired");return;}if(new RegExp("(?:^|;\\\\s*)banner-dismissed-"+id+"=true").test(document.cookie)){document.documentElement.setAttribute("data-banner-hidden","dismissed");}}catch(e){}})()`;
+  };if(exp!==null&&Date.now()>=exp){document.documentElement.setAttribute("data-banner-hidden","expired");return;}var name="banner-dismissed-"+id,pairs=document.cookie?document.cookie.split(";"):[];for(var i=0;i<pairs.length;i++){if(pairs[i].trim()===name+"=true"){document.documentElement.setAttribute("data-banner-hidden","dismissed");break;}}}catch(e){}})()`;
 
 // CSP note: this inline script requires script-src 'unsafe-inline' (or a nonce).
 // If a strict CSP is added later, move the script to /public/banner-init.js,

--- a/components/AnnouncementBanner.tsx
+++ b/components/AnnouncementBanner.tsx
@@ -1,0 +1,72 @@
+import { announcementBanner as cfg } from "@/lib/data/announcementBanner";
+import AnnouncementBannerDismiss from "./AnnouncementBannerDismiss";
+
+const safeScriptJSON = (v: unknown) =>
+  JSON.stringify(v)
+    .replace(/</g, "\\u003c")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+
+const parseExpiry = (v?: string): number | null => {
+  if (!v) return null;
+  const n = Date.parse(v);
+  if (!Number.isFinite(n)) {
+    console.warn(`[banner] invalid expiresAt: ${v}`);
+    return null;
+  }
+  return n;
+};
+
+const buildPreHideScript = (id: string, exp: number | null) =>
+  `(function(){try{var id=${safeScriptJSON(id)},exp=${
+    Number.isFinite(exp as number) ? String(exp) : "null"
+  };if(exp!==null&&Date.now()>=exp){document.documentElement.setAttribute("data-banner-hidden","expired");return;}if(new RegExp("(?:^|;\\\\s*)banner-dismissed-"+id+"=true").test(document.cookie)){document.documentElement.setAttribute("data-banner-hidden","dismissed");}}catch(e){}})()`;
+
+// CSP note: this inline script requires script-src 'unsafe-inline' (or a nonce).
+// If a strict CSP is added later, move the script to /public/banner-init.js,
+// load it with integrity/nonce, and inject { id, expiresAt } via a <meta> tag.
+
+export default function AnnouncementBanner() {
+  if (!cfg.enabled) return null;
+  const exp = parseExpiry(cfg.expiresAt);
+
+  return (
+    <>
+      {/* Ordering invariant: this <script> must precede [data-banner-role="announcement"]
+          in source order so it can set html[data-banner-hidden] before paint. */}
+      <script
+        dangerouslySetInnerHTML={{
+          __html: buildPreHideScript(cfg.id, exp),
+        }}
+      />
+      <aside
+        aria-label="Site announcement"
+        data-banner-role="announcement"
+        data-banner-id={cfg.id}
+        className="bg-surface-cream text-brand-black text-[0.84rem] leading-[1.5]"
+      >
+        <div className="max-w-7xl mx-auto flex items-center justify-center gap-3 px-6 py-2">
+          <span className="hidden md:inline font-semibold opacity-75 text-[0.78rem] tracking-wide whitespace-nowrap">
+            {cfg.date}
+          </span>
+          <span className="text-center min-w-0">
+            <strong className="font-semibold">{cfg.title}</strong>
+            {" — "}
+            {cfg.description}{" "}
+            <a
+              href={cfg.ctaHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2 font-medium whitespace-nowrap hover:opacity-80 visited:text-brand-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-cream focus-visible:ring-brand-navy"
+            >
+              {cfg.ctaText}
+              {" "}
+              <span aria-hidden="true">→</span>
+            </a>
+          </span>
+          <AnnouncementBannerDismiss bannerId={cfg.id} />
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/components/AnnouncementBannerDismiss.tsx
+++ b/components/AnnouncementBannerDismiss.tsx
@@ -19,23 +19,29 @@ export default function AnnouncementBannerDismiss({
 
   const dismiss = () => {
     try {
-      document.cookie = `banner-dismissed-${id}=true; path=/; max-age=31536000; SameSite=Lax`;
+      document.cookie = `banner-dismissed-${id}=true; path=/; max-age=31536000; SameSite=Lax; Secure`;
     } catch {}
     try {
       localStorage.setItem(`banner-dismissed-${id}`, "true");
     } catch {}
 
     const status = document.getElementById("banner-status");
-    if (status) status.textContent = "Banner dismissed";
+    if (status) status.textContent = "";
 
-    const focusTarget =
-      document.getElementById("main-content") ??
-      document.querySelector("main") ??
-      document.body;
+    const mainById = document.getElementById("main-content");
+    if (!mainById && process.env.NODE_ENV !== "production") {
+      console.warn(
+        "[AnnouncementBanner] #main-content not found on this route; falling back to <main> or <body>."
+      );
+    }
+    const focusTarget = mainById ?? document.querySelector("main") ?? document.body;
     (focusTarget as HTMLElement | null)?.focus?.({ preventScroll: true });
 
     requestAnimationFrame(() => {
-      document.documentElement.setAttribute("data-banner-hidden", "dismissed");
+      if (status) status.textContent = "Banner dismissed";
+      requestAnimationFrame(() => {
+        document.documentElement.setAttribute("data-banner-hidden", "dismissed");
+      });
     });
   };
 

--- a/components/AnnouncementBannerDismiss.tsx
+++ b/components/AnnouncementBannerDismiss.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function AnnouncementBannerDismiss({
+  bannerId: id,
+}: {
+  bannerId: string;
+}) {
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== `banner-dismissed-${id}`) return;
+      if (e.newValue !== "true") return;
+      document.documentElement.setAttribute("data-banner-hidden", "dismissed");
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [id]);
+
+  const dismiss = () => {
+    try {
+      document.cookie = `banner-dismissed-${id}=true; path=/; max-age=31536000; SameSite=Lax`;
+    } catch {}
+    try {
+      localStorage.setItem(`banner-dismissed-${id}`, "true");
+    } catch {}
+
+    const status = document.getElementById("banner-status");
+    if (status) status.textContent = "Banner dismissed";
+
+    const focusTarget =
+      document.getElementById("main-content") ??
+      document.querySelector("main") ??
+      document.body;
+    (focusTarget as HTMLElement | null)?.focus?.({ preventScroll: true });
+
+    requestAnimationFrame(() => {
+      document.documentElement.setAttribute("data-banner-hidden", "dismissed");
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={dismiss}
+      aria-label="Dismiss announcement"
+      className="w-8 h-8 -m-1 inline-flex items-center justify-center rounded text-brand-navy hover:bg-brand-navy/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-navy/40 transition-colors motion-reduce:transition-none"
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="none"
+        aria-hidden="true"
+      >
+        <path
+          d="M4 4l8 8M12 4l-8 8"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,6 +1,6 @@
 export default function HeroSection() {
   return (
-    <section className="relative h-screen -mt-[50px] pt-[50px] flex flex-col items-center justify-center bg-white overflow-hidden" aria-labelledby="hero-heading">
+    <section className="relative min-h-[calc(100svh-50px)] flex flex-col items-center justify-center bg-white overflow-hidden" aria-labelledby="hero-heading">
       {/* Guilloche background — positioned so only top 40% is visible */}
       <img
         src="/img/guilloche_02_top.svg"

--- a/lib/data/announcementBanner.ts
+++ b/lib/data/announcementBanner.ts
@@ -1,6 +1,12 @@
 /** Leaf module — no runtime deps; safe for any bundle. */
 
-export type ISODate = `${number}-${number}-${number}`;
+/**
+ * Human-readable ISO date string (e.g. "2026-05-06"). The template-literal
+ * type proved too permissive to be useful, so the shape is enforced at
+ * runtime in `parseExpiry` (AnnouncementBanner.tsx), which logs and disables
+ * expiry on any value Date.parse rejects.
+ */
+export type ISODate = string;
 
 export type AnnouncementBannerConfig = {
   /** Bump this string to re-show the banner to users who previously dismissed. */

--- a/lib/data/announcementBanner.ts
+++ b/lib/data/announcementBanner.ts
@@ -1,0 +1,26 @@
+/** Leaf module — no runtime deps; safe for any bundle. */
+
+export type ISODate = `${number}-${number}-${number}`;
+
+export type AnnouncementBannerConfig = {
+  /** Bump this string to re-show the banner to users who previously dismissed. */
+  id: string;
+  date: string;
+  title: string;
+  description: string;
+  ctaHref: string;
+  ctaText: string;
+  enabled: boolean;
+  expiresAt?: ISODate;
+};
+
+export const announcementBanner: AnnouncementBannerConfig = {
+  id: "community-call-2026-05-05",
+  date: "May 5, 2026",
+  title: "Community Call",
+  description: "Updates, demos & open Q&A.",
+  ctaHref: "https://luma.com/fcyqpplm",
+  ctaText: "RSVP on Luma",
+  enabled: true,
+  expiresAt: "2026-05-06",
+};


### PR DESCRIPTION
## Summary
- SSR-rendered, dismissable announcement banner that sits directly below the navbar on every route, mirroring the [docs site](https://github.com/hypercerts-org/documentation) pattern with a few a11y and zero-flash upgrades.
- Content is centralised in `lib/data/announcementBanner.ts` — bump `id` to re-show to everyone; the config also has `enabled` and `expiresAt`. Current announcement: **Community Call, May 5, 2026** with CTA to https://luma.com/fcyqpplm.
- A pre-paint inline script reads the dismissal cookie + expiry before hydration and toggles `html[data-banner-hidden]`, so returning dismissed users never see a flash and static generation is preserved (no `cookies()` call, no dynamic rendering).
- Dismiss writes both cookie and localStorage, moves focus to `<main>`, and announces _"Banner dismissed"_ via a persistent sr-only `aria-live="polite"` region in the root layout. A `storage` listener syncs dismissal across tabs.
- All route `<main>` elements now carry `id="main-content" tabIndex={-1}`, which also fixes a pre-existing no-op for the skip-to-content link on every page except `/`.
- `HeroSection` drops the `-mt-[50px] pt-[50px]` trick (which overlapped the banner) in favour of `min-h-[calc(100svh-50px)]`.

## Files
- **new** `lib/data/announcementBanner.ts` — typed leaf config (no React/Next imports), ISO date template type, JSDoc on `id`.
- **new** `components/AnnouncementBanner.tsx` — server component. Local `safeScriptJSON` (escapes `<`, U+2028/9), `parseExpiry` (non-throwing, warns on invalid), `buildPreHideScript` (NaN-safe epoch). Renders `<script>` then `<aside data-banner-role="announcement">`.
- **new** `components/AnnouncementBannerDismiss.tsx` — client island; click sets cookie/localStorage/focus, `requestAnimationFrame` → sets `html[data-banner-hidden="dismissed"]` so the SR live region has time to announce before the banner disappears.
- `app/layout.tsx` — mounts `<AnnouncementBanner />` between `<Header />` and `{children}`, adds persistent `#banner-status` sr-only live region.
- `app/globals.css` — one rule in `@layer base`: `html[data-banner-hidden] [data-banner-role="announcement"]{display:none !important}`.
- `app/page.tsx`, `app/blog/page.tsx`, `app/blog/[slug]/page.tsx`, `app/contact/page.tsx`, `app/privacy/page.tsx`, `app/terms/page.tsx`, `app/not-found.tsx`, `app/error.tsx` — `<main>` gets `id="main-content" tabIndex={-1}`.
- `components/HeroSection.tsx` — stop negative-margin-ing over the banner.

## Test plan
- [ ] First visit at `/`: banner visible directly under navbar, no layout shift.
- [ ] Click `×`: banner disappears, cookie `banner-dismissed-community-call-2026-05-05=true` set, focus lands on `<main>`, SR announces "Banner dismissed".
- [ ] Reload: banner stays hidden, no flash.
- [ ] Bump `cfg.id` locally: banner reappears.
- [ ] Temporarily set `expiresAt` to yesterday: banner hidden on next hard-load.
- [ ] Two tabs open → dismiss in tab A → tab B hides within ~1s without reload.
- [ ] Mobile (375px): date pill hides, content wraps, close button easily tappable.
- [ ] Keyboard-only: Tab to CTA (ring visible) → Tab to Dismiss (ring visible) → Enter → banner dismisses, focus lands on `<main>`.
- [ ] Verify on `/blog`, `/blog/<slug>`, `/contact`, `/privacy`, `/terms` — banner renders, dismiss works, focus returns to `<main>`.

## Out of scope (explicitly)
- CMS/runtime config for banner copy.
- Adding Vitest/Jest/Playwright (repo has no test runner today).
- Strict CSP migration — the pre-paint inline script would need a nonce or to move to `/public/banner-init.js`; documented in a comment in `components/AnnouncementBanner.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an announcement banner system that appears at the top of the page, can be dismissed by users, and automatically hides based on configured expiration dates.

* **Improvements**
  * Enhanced keyboard navigation and focus management across all pages for better accessibility.
  * Optimized hero section sizing for improved viewport coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->