### PR TITLE
chore(banner): point announcement banner to June 2 community call

### DIFF
--- a/lib/data/announcementBanner.ts
+++ b/lib/data/announcementBanner.ts
@@ -21,12 +21,12 @@ export type AnnouncementBannerConfig = {
 };
 
 export const announcementBanner: AnnouncementBannerConfig = {
-  id: "community-call-2026-05-05",
-  date: "May 5, 2026",
+  id: "community-call-2026-06-02",
+  date: "June 2, 2026",
   title: "Community Call",
   description: "Updates, demos & open Q&A.",
-  ctaHref: "https://luma.com/fcyqpplm",
+  ctaHref: "https://luma.com/y0dxmfa9",
   ctaText: "RSVP on Luma",
   enabled: true,
-  expiresAt: "2026-05-06",
+  expiresAt: "2026-06-03",
 };


### PR DESCRIPTION
## Summary

- Updates the homepage community-call banner to the **June 2, 2026** session.
- New RSVP link: https://luma.com/y0dxmfa9
- Bumps the banner \`id\` to \`community-call-2026-06-02\` so anyone who dismissed the May banner sees the new one (the dismiss-key lookup no longer matches).
- Pushes \`expiresAt\` to \`2026-06-03\` so the banner auto-hides the day after the call.

Mirrors the matching banner update on hypercerts-org/documentation#137.

## Test plan

- [ ] Banner renders with \"June 2, 2026\" date and \"Community Call\" title.
- [ ] CTA \"RSVP on Luma\" opens https://luma.com/y0dxmfa9 in a new tab.
- [ ] Dismiss control still hides the banner and persists across reloads.
- [ ] A browser that previously dismissed the May banner shows the June banner on next visit.
- [ ] After 2026-06-03 the banner auto-hides via \`expiresAt\`.