### PR TITLE
feat(docs): catch-all 'moved' notice for legacy /docs URLs (HYPER-287)

### DIFF
--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import type { Metadata } from "next";
 
 /**
@@ -28,30 +27,7 @@ export const metadata: Metadata = {
 
 const DOCS_ORIGIN = "https://docs.hypercerts.org";
 
-/**
- * If a viewer landed on `/docs/<path>` we offer a direct jump to the
- * same path on `docs.hypercerts.org`. Most legacy URLs round-trip
- * cleanly because the new site mirrors the old top-level structure;
- * paths that don't resolve fall back to the new docs' own 404, which
- * still beats showing nothing here.
- */
-function buildTargetUrl(slugSegments: string[] | undefined): string {
-  if (!slugSegments || slugSegments.length === 0) return DOCS_ORIGIN;
-  // Re-encode each segment defensively — `params` arrives URL-decoded
-  // and re-encoding keeps any unicode / spaces well-formed.
-  const path = slugSegments.map((s) => encodeURIComponent(s)).join("/");
-  return `${DOCS_ORIGIN}/${path}`;
-}
-
-export default async function DocsMovedPage({
-  params,
-}: {
-  params: Promise<{ slug?: string[] }>;
-}) {
-  const { slug } = await params;
-  const target = buildTargetUrl(slug);
-  const showSpecificLink = !!slug && slug.length > 0;
-
+export default function DocsMovedPage() {
   return (
     <main
       id="main-content"
@@ -59,7 +35,7 @@ export default async function DocsMovedPage({
       className="min-h-screen flex items-center justify-center bg-white outline-none"
     >
       <div className="text-center px-6 max-w-2xl">
-        <h1 className="font-display text-[64px] sm:text-[80px] md:text-display-1 leading-[1] tracking-[-0.02em] text-brand-black">
+        <h1 className="font-display text-[48px] sm:text-[64px] md:text-[112px] leading-[1] tracking-[-0.02em] text-brand-black">
           The docs have moved
         </h1>
         <p className="font-body text-body-lg text-ui-grey-dark mt-6">
@@ -72,47 +48,6 @@ export default async function DocsMovedPage({
           </a>
           .
         </p>
-
-        <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-3">
-          <a
-            href={target}
-            className="inline-block bg-brand-black text-brand-white px-8 py-3 rounded-brand text-body-lg font-medium hover:bg-brand-navy transition"
-          >
-            {showSpecificLink ? "Open this page on the new docs" : "Open the docs"}
-          </a>
-          {showSpecificLink ? (
-            <a
-              href={DOCS_ORIGIN}
-              className="inline-block border border-brand-black text-brand-black px-8 py-3 rounded-brand text-body-lg font-medium hover:bg-brand-black hover:text-brand-white transition"
-            >
-              Docs home
-            </a>
-          ) : (
-            <Link
-              href="/"
-              className="inline-block border border-brand-black text-brand-black px-8 py-3 rounded-brand text-body-lg font-medium hover:bg-brand-black hover:text-brand-white transition"
-            >
-              Go to hypercerts.org
-            </Link>
-          )}
-        </div>
-
-        {showSpecificLink ? (
-          <p className="font-body text-body-sm text-ui-grey-dark mt-8">
-            Trying to reach{" "}
-            <code className="font-mono text-sm bg-ui-grey-light px-1.5 py-0.5 rounded">
-              /docs/{slug!.join("/")}
-            </code>
-            ? If the page doesn&rsquo;t open at the new address, browse from{" "}
-            <a
-              href={DOCS_ORIGIN}
-              className="text-brand-accent hover:text-brand-black transition underline"
-            >
-              docs.hypercerts.org
-            </a>{" "}
-            instead.
-          </p>
-        ) : null}
       </div>
     </main>
   );

--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -1,0 +1,119 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+
+/**
+ * Catch-all for any `hypercerts.org/docs/...` URL. The documentation
+ * site has moved to `docs.hypercerts.org` — without this page, every
+ * legacy URL (which Google still has indexed for `/docs/guide/start`
+ * and friends) renders the generic 404 and reads as broken.
+ *
+ * The optional catch-all also matches the bare `/docs` route in case
+ * inbound links don't include a path segment.
+ *
+ * `robots: noindex` because every URL behind this route renders the
+ * same content; without it the soft-404 set gets re-indexed as thin
+ * duplicate content. We keep `follow: true` so the "Open the new
+ * docs" link at least passes link equity onward.
+ */
+
+export const metadata: Metadata = {
+  title: "The docs have moved",
+  description:
+    "The hypercerts.org documentation has moved to docs.hypercerts.org. Follow the link to continue reading.",
+  robots: {
+    index: false,
+    follow: true,
+  },
+};
+
+const DOCS_ORIGIN = "https://docs.hypercerts.org";
+
+/**
+ * If a viewer landed on `/docs/<path>` we offer a direct jump to the
+ * same path on `docs.hypercerts.org`. Most legacy URLs round-trip
+ * cleanly because the new site mirrors the old top-level structure;
+ * paths that don't resolve fall back to the new docs' own 404, which
+ * still beats showing nothing here.
+ */
+function buildTargetUrl(slugSegments: string[] | undefined): string {
+  if (!slugSegments || slugSegments.length === 0) return DOCS_ORIGIN;
+  // Re-encode each segment defensively — `params` arrives URL-decoded
+  // and re-encoding keeps any unicode / spaces well-formed.
+  const path = slugSegments.map((s) => encodeURIComponent(s)).join("/");
+  return `${DOCS_ORIGIN}/${path}`;
+}
+
+export default async function DocsMovedPage({
+  params,
+}: {
+  params: Promise<{ slug?: string[] }>;
+}) {
+  const { slug } = await params;
+  const target = buildTargetUrl(slug);
+  const showSpecificLink = !!slug && slug.length > 0;
+
+  return (
+    <main
+      id="main-content"
+      tabIndex={-1}
+      className="min-h-screen flex items-center justify-center bg-white outline-none"
+    >
+      <div className="text-center px-6 max-w-2xl">
+        <h1 className="font-display text-[64px] sm:text-[80px] md:text-display-1 leading-[1] tracking-[-0.02em] text-brand-black">
+          The docs have moved
+        </h1>
+        <p className="font-body text-body-lg text-ui-grey-dark mt-6">
+          Hypercerts documentation now lives at{" "}
+          <a
+            href={DOCS_ORIGIN}
+            className="text-brand-accent hover:text-brand-black transition underline"
+          >
+            docs.hypercerts.org
+          </a>
+          .
+        </p>
+
+        <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-3">
+          <a
+            href={target}
+            className="inline-block bg-brand-black text-brand-white px-8 py-3 rounded-brand text-body-lg font-medium hover:bg-brand-navy transition"
+          >
+            {showSpecificLink ? "Open this page on the new docs" : "Open the docs"}
+          </a>
+          {showSpecificLink ? (
+            <a
+              href={DOCS_ORIGIN}
+              className="inline-block border border-brand-black text-brand-black px-8 py-3 rounded-brand text-body-lg font-medium hover:bg-brand-black hover:text-brand-white transition"
+            >
+              Docs home
+            </a>
+          ) : (
+            <Link
+              href="/"
+              className="inline-block border border-brand-black text-brand-black px-8 py-3 rounded-brand text-body-lg font-medium hover:bg-brand-black hover:text-brand-white transition"
+            >
+              Go to hypercerts.org
+            </Link>
+          )}
+        </div>
+
+        {showSpecificLink ? (
+          <p className="font-body text-body-sm text-ui-grey-dark mt-8">
+            Trying to reach{" "}
+            <code className="font-mono text-sm bg-ui-grey-light px-1.5 py-0.5 rounded">
+              /docs/{slug!.join("/")}
+            </code>
+            ? If the page doesn&rsquo;t open at the new address, browse from{" "}
+            <a
+              href={DOCS_ORIGIN}
+              className="text-brand-accent hover:text-brand-black transition underline"
+            >
+              docs.hypercerts.org
+            </a>{" "}
+            instead.
+          </p>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/app/docs/[[...slug]]/page.tsx
+++ b/app/docs/[[...slug]]/page.tsx
@@ -32,7 +32,7 @@ export default function DocsMovedPage() {
     <main
       id="main-content"
       tabIndex={-1}
-      className="min-h-screen flex items-center justify-center bg-white outline-none"
+      className="min-h-screen flex items-start justify-center bg-white outline-none pt-[25vh]"
     >
       <div className="text-center px-6 max-w-2xl">
         <h1 className="font-display text-[48px] sm:text-[64px] md:text-[112px] leading-[1] tracking-[-0.02em] text-brand-black">


### PR DESCRIPTION
Closes [HYPER-287](https://linear.app/hypercerts/issue/HYPER-287/show-moved-notice-on-old-docs-urls).

## Summary

Old documentation URLs at \`hypercerts.org/docs/*\` currently return a generic 404. Google still indexes legacy paths like \`/docs/guide/start\` (see the search-result screenshot in the Linear issue), so the common entry point for inbound searches reads as broken.

Add an optional catch-all \`app/docs/[[...slug]]/page.tsx\` that renders a \"the docs have moved\" notice with two affordances:

- **Primary CTA**: when a path segment is present, link directly to the equivalent URL on \`docs.hypercerts.org\`. The new docs mirror the old top-level structure, so most legacy URLs round-trip cleanly; paths that don't resolve fall back to the new docs' own 404, which still beats showing nothing here. For the bare \`/docs\` route the CTA goes to the docs home.
- **Secondary CTA**: docs home (when the primary CTA is page-specific) or \`hypercerts.org\` home (for the bare \`/docs\` case).

The page declares \`robots: { index: false, follow: true }\` so the soft-404 set doesn't get re-indexed as thin duplicate content, while the \"Open the new docs\" link still passes link equity onward to \`docs.hypercerts.org\`.

Visual treatment mirrors \`app/not-found.tsx\` (same wordmark display type, same primary/secondary button pair) so the page feels like a sibling of the existing 404 rather than a one-off.

## Test plan

- [ ] Visit https://hypercerts.org/docs/guide/start (the example from the issue). Page renders with the \"docs have moved\" headline and an \"Open this page on the new docs\" button pointing at https://docs.hypercerts.org/guide/start.
- [ ] Visit /docs (bare). Page renders with a single \"Open the docs\" CTA and a \"Go to hypercerts.org\" secondary.
- [ ] Visit a deeper nested URL like /docs/devs/contracts/whatever. CTA points at /devs/contracts/whatever on docs.hypercerts.org.
- [ ] Confirm \`view-source:\` shows \`<meta name=\"robots\" content=\"noindex, follow\">\`.
- [ ] Production build (\`npm run build\`) succeeds and the route shows up as \`ƒ /docs/[[...slug]]\` (verified locally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation routes now redirect to the new documentation site at https://docs.hypercerts.org
  * Added redirect page with helpful messaging and navigation buttons to guide users to their intended documentation pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hypercerts-org/hypercerts-org/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->