### PR TITLE
feat(docs): permanent-redirect the bare /docs to docs.hypercerts.org

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,20 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  async redirects() {
+    return [
+      // The bare /docs URL (and any explicit-trailing-slash variant)
+      // resolves directly to the new docs site. Sub-paths like
+      // /docs/guide/start still fall through to the catch-all at
+      // `app/docs/[[...slug]]/page.tsx`, which renders the "moved"
+      // notice with a link to the equivalent path on docs.
+      {
+        source: "/docs",
+        destination: "https://docs.hypercerts.org",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Follow-up to #13.

## Summary

The bare \`hypercerts.org/docs\` URL still routes through the catch-all moved-notice page, which makes the visitor click \"Open the docs\" before reaching anything. For that exact path there's nothing to disambiguate — they just want the docs — so emit a 308 redirect straight to the new home.

Sub-paths (e.g. \`/docs/guide/start\`) still fall through to \`app/docs/[[...slug]]/page.tsx\` so the user-visible \"moved\" notice continues to render with a link to the equivalent path on the new site.

## Diff

Single change to \`next.config.ts\` — a \`redirects()\` entry mapping \`/docs\` → \`https://docs.hypercerts.org\` (permanent).

## Test plan

- [ ] Visit https://hypercerts.org/docs → lands on https://docs.hypercerts.org (308).
- [ ] Visit https://hypercerts.org/docs/ (trailing slash) → same.
- [ ] Visit https://hypercerts.org/docs/guide/start → still renders the \"moved\" notice page (unchanged behaviour).
- [ ] \`npm run build\` succeeds (verified locally).