### PR TITLE
chore(banner): point announcement banner to July 14 community call

### DIFF
--- a/lib/data/announcementBanner.ts
+++ b/lib/data/announcementBanner.ts
@@ -21,12 +21,12 @@ export type AnnouncementBannerConfig = {
 };
 
 export const announcementBanner: AnnouncementBannerConfig = {
-  id: "community-call-2026-06-02",
-  date: "June 2, 2026",
+  id: "community-call-2026-07-14",
+  date: "July 14, 2026",
   title: "Community Call",
   description: "Updates, demos & open Q&A.",
-  ctaHref: "https://luma.com/y0dxmfa9",
+  ctaHref: "https://luma.com/5yivfrkt",
   ctaText: "RSVP on Luma",
   enabled: true,
-  expiresAt: "2026-06-03",
+  expiresAt: "2026-07-15",
 };


### PR DESCRIPTION
## What

Repoints the site-wide announcement banner to the **July 14, 2026** community call.

| Field | Value |
|---|---|
| `id` | `community-call-2026-07-14` (bumped) |
| `date` | July 14, 2026 |
| `ctaHref` | https://luma.com/5yivfrkt |
| `expiresAt` | `2026-07-15` |

## Why

The previous banner (June 2 call) expired on `2026-06-03` and is no longer shown. This surfaces the next call.

## Behavior

- Bumping `id` re-shows the banner to anyone who dismissed the previous one (the `banner-dismissed-<id>` cookie key no longer matches).
- `expiresAt: 2026-07-15` makes the pre-paint script auto-hide the banner the day after the call (evaluated at UTC midnight).
- `enabled` stays `true`; `title` / `description` / `ctaText` unchanged.

Single-file change: `lib/data/announcementBanner.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the announcement banner for the July 2026 event.
  * Added the new RSVP link while preserving the existing banner content and visibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->